### PR TITLE
Add detailed JavaDoc to DateHelper and CertificateHelper

### DIFF
--- a/src/main/java/nl/novi/eindopdracht_cursusadministratie/helper/CertificateNumberHelper.java
+++ b/src/main/java/nl/novi/eindopdracht_cursusadministratie/helper/CertificateNumberHelper.java
@@ -3,10 +3,24 @@ package nl.novi.eindopdracht_cursusadministratie.helper;
 import java.time.LocalDate;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * De {@code CertificateNumberHelper} genereert unieke certificaatnummers.
+ * <p>
+ * Elk certificaatnummer bestaat uit het huidige jaar, gevolgd door een
+ * viercijferig oplopend volgnummer (bijv. 2025-0001).
+ */
 public class CertificateNumberHelper {
 
     private static final AtomicInteger counter = new AtomicInteger(1);
 
+    /**
+     * Genereert een uniek certificaatnummer.
+     * <p>
+     * Het nummer heeft het formaat {@code JAAR-XXXX}, waarbij {@code XXXX}
+     * automatisch wordt opgehoogd per gegenereerd certificaat.
+     *
+     * @return een nieuw certificaatnummer, bijvoorbeeld {@code 2025-0001}
+     */
     public static String generateCertificateNumber() {
         String year = String.valueOf(LocalDate.now().getYear());
         String formattedCounter = String.format("%04d", counter.getAndIncrement());

--- a/src/main/java/nl/novi/eindopdracht_cursusadministratie/helper/DateHelper.java
+++ b/src/main/java/nl/novi/eindopdracht_cursusadministratie/helper/DateHelper.java
@@ -3,8 +3,24 @@ package nl.novi.eindopdracht_cursusadministratie.helper;
 import nl.novi.eindopdracht_cursusadministratie.model.course.TrainingType;
 import java.time.LocalDate;
 
+/**
+ * De {@code DateHelper} biedt hulpfuncties voor het werken met datums
+ * binnen het certificaatsysteem.
+ * <p>
+ * Deze klasse wordt voornamelijk gebruikt om de vervaldatum van een certificaat
+ * te berekenen op basis van het trainingstype en de uitgiftedatum.
+ */
 public class DateHelper {
 
+    /**
+     * Berekent de vervaldatum van een certificaat op basis van het type training.
+     * <p>
+     * Bijvoorbeeld: een BHV-certificaat is 1 jaar geldig, terwijl EHBO 2 jaar geldig is.
+     *
+     * @param issueDate de datum waarop het certificaat is uitgegeven
+     * @param type      het trainingstype (bevat de geldigheidsduur in jaren)
+     * @return de berekende vervaldatum als {@link LocalDate}
+     */
     public static LocalDate calculateExpiryDate(LocalDate issueDate, TrainingType type) {
         return issueDate.plusYears(type.getGeldigheidInJaren());
     }


### PR DESCRIPTION
Added full JavaDoc documentation to helper classes:

- DateHelper: explains logic for calculating certificate expiry dates.
- CertificateNumberHelper: documents auto-generation of unique certificate numbers.

This improves code readability, maintainability, and aligns helper classes
with the same documentation standards used for EvacuationHelper.
